### PR TITLE
fix(warnings): use regex as string refs #253293

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const applyConfig = (config) => {
     ...(config.settings.externalRoutes || []),
     {
       match: {
-        path: notInEN,
+        path: notInEN.source,
         exact: false,
         strict: false,
       },

--- a/src/index.js
+++ b/src/index.js
@@ -17,12 +17,13 @@ const restrictedBlocks = [
 
 const applyConfig = (config) => {
   // #158717#note-25 any path that isn't static, en or controlpanel is treated as external
-  const notInEN = /^(?!.*(#|\/en|\/static|\/controlpanel|\/cypress|\/login|\/logout|\/contact-form)).*$/;
+  const notInEN =
+    '**/!(en|static|controlpanel|cypress|login|logout|contact-form)';
   config.settings.externalRoutes = [
     ...(config.settings.externalRoutes || []),
     {
       match: {
-        path: notInEN.source,
+        path: notInEN,
         exact: false,
         strict: false,
       },

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ const restrictedBlocks = [
 const applyConfig = (config) => {
   // #158717#note-25 any path that isn't static, en or controlpanel is treated as external
   const notInEN =
-    '**/!(en|static|controlpanel|cypress|login|logout|contact-form)';
+    '!/en/!(login*|logout*|static*|controlpanel*|cypress*|contact-form*)';
   config.settings.externalRoutes = [
     ...(config.settings.externalRoutes || []),
     {


### PR DESCRIPTION
```Warning: Failed prop type: Invalid prop `path` supplied to `Route`, expected one of type [string].      ```